### PR TITLE
Do not check for `nightly-results` any more

### DIFF
--- a/nightly.sh
+++ b/nightly.sh
@@ -6,4 +6,4 @@ opam update
 opam upgrade -y
 opam install core dune menhir ppx_deriving ppx_sexp_conv yojson core_unix -y
 python3 run.py
-python3 report.py
+python3 report.py --no-open

--- a/report.py
+++ b/report.py
@@ -1,4 +1,5 @@
 import datetime
+import sys
 import os
 import dominate
 from dominate.tags import *
@@ -478,5 +479,5 @@ write_to(out_path + "index.html", str(doc))
 output_tex(f"\\newcommand{{\\TotalDiffCount}}{{{total_diff_count}}}\n")
 output_tex(f"\\newcommand{{\\TotalTraceCount}}{{{len(trace_list)}}}\n")
 
-if subprocess.run("command -v nightly-results", shell=True).returncode != 0:
+if "--no-open" not in sys.argv:
     subprocess.run(f"xdg-open {out_path}/index.html", shell=True, check=True)


### PR DESCRIPTION
I'm trying to get rid of `nightly-results` entirely; this PR removes Megatron's last use of it, a check for whether or not it needs to call `xdg-open`. I replace it with a special command-line argument that only the nightly passes.